### PR TITLE
Fix Slack message so that link is not broken.

### DIFF
--- a/lunchroulette.rb
+++ b/lunchroulette.rb
@@ -173,9 +173,9 @@ groups.each do |group|
   client.chat_postMessage(
     channel: group_chat['id'],
     link_names: 1,
-    text: "_Psst: Don't understand what Lunch Roulette is? " \
+    text: "Psst: Don't understand what Lunch Roulette is? " \
       "More information here: " \
-      "https://github.com/toothbrush/lunch-roulette/wiki._",
+      "https://github.com/toothbrush/lunch-roulette/wiki",
     as_user: true
   )
 


### PR DESCRIPTION
Why the change:
Reduces confusion from recipients who receive link, and follow it to a 404.

Why was the change reqired to achieve that?
Something about the way the Slack API processes messages meant that the trailing `.` and `_` characters were added to the URL itself.